### PR TITLE
Add interleaved yuv formats

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Andy Regensky
+Copyright (c) 2021-2025 Andy Regensky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ Currently, the following pixel formats (`pix_fmt`) are available:
 * `'yuv444p12be'`
 * `'yuv444p14le'`
 * `'yuv444p14be'`
-* `'yuv420p'`
 
 **Interleaved YUV 4:2:0**
 (*Even lines carry luma and chroma [y0 u0 y1 v0 ...], odd lines carry only luma [y0 y1 ...]*)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ To get detailed information on the IO format of a specific `pix_fmt` use
 `print(yuvio.pixel_formats[pix_fmt].io_info())`.
 
 Currently, the following pixel formats (`pix_fmt`) are available:
+
+**Grayscale/YUV 4:0:0**
 * `'gray'`
 * `'gray10le'`
 * `'gray10be'`
@@ -129,8 +131,8 @@ Currently, the following pixel formats (`pix_fmt`) are available:
 * `'gray12be'`
 * `'gray14le'`
 * `'gray14be'`
-* `'nv12'`
-* `'v210'`
+
+**Planar YUV 4:2:0**
 * `'yuv420p'`
 * `'yuv420p10le'`
 * `'yuv420p10be'`
@@ -142,6 +144,11 @@ Currently, the following pixel formats (`pix_fmt`) are available:
 * `'yuv420p12be'`
 * `'yuv420p14le'`
 * `'yuv420p14be'`
+
+**Semi-planar YUV 4:2:0**
+* `'nv12'`
+
+**Planar YUV 4:2:2**
 * `'yuv422p'`
 * `'yuv422p10le'`
 * `'yuv422p10be'`
@@ -153,6 +160,8 @@ Currently, the following pixel formats (`pix_fmt`) are available:
 * `'yuv422p12be'`
 * `'yuv422p14le'`
 * `'yuv422p14be'`
+
+**Planar YUV 4:4:4**
 * `'yuv444p'`
 * `'yuv444p10le'`
 * `'yuv444p10be'`
@@ -165,6 +174,10 @@ Currently, the following pixel formats (`pix_fmt`) are available:
 * `'yuv444p14le'`
 * `'yuv444p14be'`
 * `'yuv420p'`
+
+**Interleaved YUV 4:2:0**
+(*Even lines carry luma and chroma [y0 u0 y1 v0 ...], odd lines carry only luma [y0 y1 ...]*)
+* `'yuv420i'`
 * `'yuv420i10le'`
 * `'yuv420i10be'`
 * `'yuv420i16le'`
@@ -175,6 +188,35 @@ Currently, the following pixel formats (`pix_fmt`) are available:
 * `'yuv420i12be'`
 * `'yuv420i14le'`
 * `'yuv420i14be'`
-* `'yuyv422'`
+
+**Interleaved YUV 4:2:2**
+* `'yuv422i'`
+* `'yuv422i10le'`
+* `'yuv422i10be'`
+* `'yuv422i16le'`
+* `'yuv422i16be'`
+* `'yuv422i9le'`
+* `'yuv422i9be'`
+* `'yuv422i12le'`
+* `'yuv422i12be'`
+* `'yuv422i14le'`
+* `'yuv422i14be'`
+* `'yuyv422'`: Same as `'yuv422i'`
 * `'uyvy422'`
 * `'yvyu422'`
+
+**Interleaved YUV 4:4:4**
+* `'yuv444i'`
+* `'yuv444i10le'`
+* `'yuv444i10be'`
+* `'yuv444i16le'`
+* `'yuv444i16be'`
+* `'yuv444i9le'`
+* `'yuv444i9be'`
+* `'yuv444i12le'`
+* `'yuv444i12be'`
+* `'yuv444i14le'`
+* `'yuv444i14be'`
+
+**Special formats**
+* `'v210'`

--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ Currently, the following pixel formats (`pix_fmt`) are available:
 * `'yuv444p12be'`
 * `'yuv444p14le'`
 * `'yuv444p14be'`
+* `'yuv420p'`
+* `'yuv420i10le'`
+* `'yuv420i10be'`
+* `'yuv420i16le'`
+* `'yuv420i16be'`
+* `'yuv420i9le'`
+* `'yuv420i9be'`
+* `'yuv420i12le'`
+* `'yuv420i12be'`
+* `'yuv420i14le'`
+* `'yuv420i14be'`
 * `'yuyv422'`
 * `'uyvy422'`
 * `'yvyu422'`

--- a/yuvio/core/reader.py
+++ b/yuvio/core/reader.py
@@ -11,18 +11,27 @@ class Reader:
 
     def __init__(self, file: Union[Path, str, io.RawIOBase, io.BufferedIOBase], format: Format):
         if isinstance(file, io.RawIOBase) or isinstance(file, io.BufferedIOBase):
-            self._close = False
+            self._owns = False
             self._file = file
         else:
-            self._close = True
+            self._owns = True
             self._file = open(Path(file).expanduser().resolve(), 'rb')
+            self._open = True
         self._format = format
         self._length = self._length_from_stream()
         self._iter_idx = 0
 
+    def close(self):
+        if not self._owns:
+            raise RuntimeError("Cannot close unowned IO handle.")
+        if not self._open:
+            raise IOError("File is already closed.")
+        self._file.close()
+        self._open = False
+
     def __del__(self):
-        if self._close:
-            self._file.close()
+        if self._owns and self._open:
+            self.close()
 
     def __len__(self):
         return self._length

--- a/yuvio/formats/__init__.py
+++ b/yuvio/formats/__init__.py
@@ -12,6 +12,7 @@ from .yuv420p import (YUV420P,
                       YUV420P9LE, YUV420P9BE,
                       YUV420P12LE, YUV420P12BE,
                       YUV420P14LE, YUV420P14BE)
+from .yuv420i import (YUV420I)
 from .yuv422p import (YUV422P,
                       YUV422P10LE, YUV422P10BE,
                       YUV422P16LE, YUV422P16BE,

--- a/yuvio/formats/__init__.py
+++ b/yuvio/formats/__init__.py
@@ -12,17 +12,34 @@ from .yuv420p import (YUV420P,
                       YUV420P9LE, YUV420P9BE,
                       YUV420P12LE, YUV420P12BE,
                       YUV420P14LE, YUV420P14BE)
-from .yuv420i import (YUV420I)
+from .yuv420i import (YUV420I,
+                      YUV420I10LE, YUV420I10BE,
+                      YUV420I16LE, YUV420I16BE,
+                      YUV420I9LE, YUV420I9BE,
+                      YUV420I12LE, YUV420I12BE,
+                      YUV420I14LE, YUV420I14BE)
 from .yuv422p import (YUV422P,
                       YUV422P10LE, YUV422P10BE,
                       YUV422P16LE, YUV422P16BE,
                       YUV422P9LE, YUV422P9BE,
                       YUV422P12LE, YUV422P12BE,
                       YUV422P14LE, YUV422P14BE)
+from .yuv422i import (YUV422I,
+                      YUV422I10LE, YUV422I10BE,
+                      YUV422I16LE, YUV422I16BE,
+                      YUV422I9LE, YUV422I9BE,
+                      YUV422I12LE, YUV422I12BE,
+                      YUV422I14LE, YUV422I14BE)
 from .yuv444p import (YUV444P,
                       YUV444P10LE, YUV444P10BE,
                       YUV444P16LE, YUV444P16BE,
                       YUV444P9LE, YUV444P9BE,
                       YUV444P12LE, YUV444P12BE,
                       YUV444P14LE, YUV444P14BE)
+from .yuv444i import (YUV444I,
+                      YUV444I10LE, YUV444I10BE,
+                      YUV444I16LE, YUV444I16BE,
+                      YUV444I9LE, YUV444I9BE,
+                      YUV444I12LE, YUV444I12BE,
+                      YUV444I14LE, YUV444I14BE)
 from .yuyv422 import (YUYV422, UYVY422, YVYU422)

--- a/yuvio/formats/yuv420i.py
+++ b/yuvio/formats/yuv420i.py
@@ -1,0 +1,279 @@
+from abc import ABC
+import numpy as np
+from .. import pixel_formats
+from ..core import Format
+
+
+class _YUV420IBase(Format, ABC):
+    """Base for all interleaved yuv420 formats."""
+    @staticmethod
+    def chroma_subsampling():
+        return 2, 2
+
+    def unpack(self, data):
+        even_lines = data['frame']['even_line']
+        odd_lines = data['frame']['odd_line']
+
+        frames = even_lines.shape[0]
+        y = np.empty((frames, self._height, self._width), dtype=even_lines['y0'].dtype)
+
+        y[:, 0::2, 0::2] = even_lines['y0']
+        y[:, 0::2, 1::2] = even_lines['y1']
+        y[:, 1::2, :] = odd_lines
+        u = even_lines['u0']
+        v = even_lines['v0']
+        return y, u, v
+
+    def pack(self, yuv):
+        y, u, v = yuv
+        data = np.empty(y.shape[0], dtype=self.dtype)
+        data['frame']['even_line']['y0'][:] = y[:, 0::2, 0::2]
+        data['frame']['even_line']['y1'][:] = y[:, 0::2, 1::2]
+        data['frame']['odd_line'][:] = y[:, 1::2, :]
+        data['frame']['even_line']['u0'][:] = u
+        data['frame']['even_line']['v0'][:] = v
+        return data
+
+
+class YUV420I(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i"
+
+    @staticmethod
+    def bitdepth():
+        return 8
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', "<u1"), ('u0', "<u1"), ('y1', "<u1"), ('v0', "<u1")], (self._width // 2)),
+                ('odd_line', "<u1", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I10LE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i10le"
+
+    @staticmethod
+    def bitdepth():
+        return 10
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', "<u2"), ('u0', "<u2"), ('y1', "<u2"), ('v0', "<u2")], (self._width // 2)),
+                ('odd_line', "<u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I10BE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i10be"
+
+    @staticmethod
+    def bitdepth():
+        return 10
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', ">u2"), ('u0', ">u2"), ('y1', ">u2"), ('v0', ">u2")], (self._width // 2)),
+                ('odd_line', ">u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I16LE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i16le"
+
+    @staticmethod
+    def bitdepth():
+        return 16
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', "<u2"), ('u0', "<u2"), ('y1', "<u2"), ('v0', "<u2")], (self._width // 2)),
+                ('odd_line', "<u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I16BE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i16be"
+
+    @staticmethod
+    def bitdepth():
+        return 16
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', ">u2"), ('u0', ">u2"), ('y1', ">u2"), ('v0', ">u2")], (self._width // 2)),
+                ('odd_line', ">u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I9LE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i9le"
+
+    @staticmethod
+    def bitdepth():
+        return 9
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', "<u2"), ('u0', "<u2"), ('y1', "<u2"), ('v0', "<u2")], (self._width // 2)),
+                ('odd_line', "<u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I9BE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i9be"
+
+    @staticmethod
+    def bitdepth():
+        return 9
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', ">u2"), ('u0', ">u2"), ('y1', ">u2"), ('v0', ">u2")], (self._width // 2)),
+                ('odd_line', ">u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I12LE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i12le"
+
+    @staticmethod
+    def bitdepth():
+        return 12
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', "<u2"), ('u0', "<u2"), ('y1', "<u2"), ('v0', "<u2")], (self._width // 2)),
+                ('odd_line', "<u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I12BE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i12be"
+
+    @staticmethod
+    def bitdepth():
+        return 12
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', ">u2"), ('u0', ">u2"), ('y1', ">u2"), ('v0', ">u2")], (self._width // 2)),
+                ('odd_line', ">u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I14LE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i14le"
+
+    @staticmethod
+    def bitdepth():
+        return 14
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', "<u2"), ('u0', "<u2"), ('y1', "<u2"), ('v0', "<u2")], (self._width // 2)),
+                ('odd_line', "<u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+class YUV420I14BE(_YUV420IBase):
+    @staticmethod
+    def identifier():
+        return "yuv420i14be"
+
+    @staticmethod
+    def bitdepth():
+        return 14
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [
+                ('even_line', [('y0', ">u2"), ('u0', ">u2"), ('y1', ">u2"), ('v0', ">u2")], (self._width // 2)),
+                ('odd_line', ">u2", self._width)
+             ],
+             (self._height // 2))
+        ])
+
+
+pixel_formats.register(YUV420I)
+pixel_formats.register(YUV420I10LE)
+pixel_formats.register(YUV420I10BE)
+pixel_formats.register(YUV420I16LE)
+pixel_formats.register(YUV420I16BE)
+pixel_formats.register(YUV420I9LE)
+pixel_formats.register(YUV420I9BE)
+pixel_formats.register(YUV420I12LE)
+pixel_formats.register(YUV420I12BE)
+pixel_formats.register(YUV420I14LE)
+pixel_formats.register(YUV420I14BE)

--- a/yuvio/formats/yuv422i.py
+++ b/yuvio/formats/yuv422i.py
@@ -1,0 +1,273 @@
+from abc import ABC
+import numpy as np
+from .. import pixel_formats
+from ..core import Format
+
+
+class _YUV422IBase(Format, ABC):
+    """Base for all interleaved yuv422 formats."""
+    @staticmethod
+    def chroma_subsampling():
+        return 2, 1
+
+    def unpack(self, data):
+        y = np.stack((data['frame']['y0'],
+                      data['frame']['y1']), 3).reshape((-1, self._height, self._width))
+        u = data['frame']['u0']
+        v = data['frame']['v0']
+        return y, u, v
+
+    def pack(self, yuv):
+        y, u, v = yuv
+        data = np.empty(y.shape[0], dtype=self.dtype)
+        y = y.reshape((-1, self._height, self._width // 2, 2))
+        y0, y1 = y[:, :, :, 0], y[:, :, :, 1]
+        data['frame']['y0'][:] = y0
+        data['frame']['u0'][:] = u
+        data['frame']['y1'][:] = y1
+        data['frame']['v0'][:] = v
+        return data
+
+
+class YUV422I(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i"
+
+    @staticmethod
+    def bitdepth():
+        return 8
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', "<u1"),
+              ('u0', "<u1"),
+              ('y1', "<u1"),
+              ('v0', "<u1")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I10LE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i10le"
+
+    @staticmethod
+    def bitdepth():
+        return 10
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', "<u2"),
+              ('u0', "<u2"),
+              ('y1', "<u2"),
+              ('v0', "<u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I10BE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i10be"
+
+    @staticmethod
+    def bitdepth():
+        return 10
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', ">u2"),
+              ('u0', ">u2"),
+              ('y1', ">u2"),
+              ('v0', ">u2")],
+             (self._height, self._width // 2))
+        ])
+    
+
+class YUV422I16LE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i16le"
+
+    @staticmethod
+    def bitdepth():
+        return 16
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', "<u2"),
+              ('u0', "<u2"),
+              ('y1', "<u2"),
+              ('v0', "<u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I16BE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i16be"
+
+    @staticmethod
+    def bitdepth():
+        return 16
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', ">u2"),
+              ('u0', ">u2"),
+              ('y1', ">u2"),
+              ('v0', ">u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I9LE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i9le"
+
+    @staticmethod
+    def bitdepth():
+        return 9
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', "<u2"),
+              ('u0', "<u2"),
+              ('y1', "<u2"),
+              ('v0', "<u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I9BE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i9be"
+
+    @staticmethod
+    def bitdepth():
+        return 9
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', ">u2"),
+              ('u0', ">u2"),
+              ('y1', ">u2"),
+              ('v0', ">u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I12LE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i12le"
+
+    @staticmethod
+    def bitdepth():
+        return 12
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', "<u2"),
+              ('u0', "<u2"),
+              ('y1', "<u2"),
+              ('v0', "<u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I12BE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i12be"
+
+    @staticmethod
+    def bitdepth():
+        return 12
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', ">u2"),
+              ('u0', ">u2"),
+              ('y1', ">u2"),
+              ('v0', ">u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I14LE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i14le"
+
+    @staticmethod
+    def bitdepth():
+        return 14
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', "<u2"),
+              ('u0', "<u2"),
+              ('y1', "<u2"),
+              ('v0', "<u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+class YUV422I14BE(_YUV422IBase):
+    @staticmethod
+    def identifier():
+        return "yuv422i14be"
+
+    @staticmethod
+    def bitdepth():
+        return 14
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y0', ">u2"),
+              ('u0', ">u2"),
+              ('y1', ">u2"),
+              ('v0', ">u2")],
+             (self._height, self._width // 2))
+        ])
+
+
+pixel_formats.register(YUV422I)
+pixel_formats.register(YUV422I10LE)
+pixel_formats.register(YUV422I10BE)
+pixel_formats.register(YUV422I16LE)
+pixel_formats.register(YUV422I16BE)
+pixel_formats.register(YUV422I9LE)
+pixel_formats.register(YUV422I9BE)
+pixel_formats.register(YUV422I12LE)
+pixel_formats.register(YUV422I12BE)
+pixel_formats.register(YUV422I14LE)
+pixel_formats.register(YUV422I14BE)

--- a/yuvio/formats/yuv444i.py
+++ b/yuvio/formats/yuv444i.py
@@ -1,0 +1,257 @@
+from abc import ABC
+import numpy as np
+from .. import pixel_formats
+from ..core import Format
+
+
+class _YUV444IBase(Format, ABC):
+    """Base for all interleaved yuv444 formats."""
+    @staticmethod
+    def chroma_subsampling():
+        return 1, 1
+
+    def unpack(self, data):
+        y = data['frame']['y']
+        u = data['frame']['u']
+        v = data['frame']['v']
+        return y, u, v
+
+    def pack(self, yuv):
+        data = np.empty(y.shape[0], dtype=self.dtype)
+        data['frame']['y'][:] = yuv[0]
+        data['frame']['u'][:] = yuv[1]
+        data['frame']['v'][:] = yuv[2]
+        return data
+
+
+class YUV444I(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i"
+
+    @staticmethod
+    def bitdepth():
+        return 8
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', "<u1"),
+              ('u', "<u1"),
+              ('v', "<u1")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I10LE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i10le"
+
+    @staticmethod
+    def bitdepth():
+        return 10
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', "<u2"),
+              ('u', "<u2"),
+              ('v', "<u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I10BE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i10be"
+
+    @staticmethod
+    def bitdepth():
+        return 10
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', ">u2"),
+              ('u', ">u2"),
+              ('v', ">u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I16LE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i16le"
+
+    @staticmethod
+    def bitdepth():
+        return 16
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', "<u2"),
+              ('u', "<u2"),
+              ('v', "<u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I16BE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i16be"
+
+    @staticmethod
+    def bitdepth():
+        return 16
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', ">u2"),
+              ('u', ">u2"),
+              ('v', ">u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I9LE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i9le"
+
+    @staticmethod
+    def bitdepth():
+        return 9
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', "<u2"),
+              ('u', "<u2"),
+              ('v', "<u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I9BE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i9be"
+
+    @staticmethod
+    def bitdepth():
+        return 9
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', ">u2"),
+              ('u', ">u2"),
+              ('v', ">u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I12LE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i12le"
+
+    @staticmethod
+    def bitdepth():
+        return 12
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', "<u2"),
+              ('u', "<u2"),
+              ('v', "<u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I12BE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i12be"
+
+    @staticmethod
+    def bitdepth():
+        return 12
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', ">u2"),
+              ('u', ">u2"),
+              ('v', ">u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I14LE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i14le"
+
+    @staticmethod
+    def bitdepth():
+        return 14
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', "<u2"),
+              ('u', "<u2"),
+              ('v', "<u2")],
+             (self._height, self._width))
+        ])
+
+
+class YUV444I14BE(_YUV444IBase):
+    @staticmethod
+    def identifier():
+        return "yuv444i14be"
+
+    @staticmethod
+    def bitdepth():
+        return 14
+
+    @property
+    def dtype(self):
+        return np.dtype([
+            ('frame',
+             [('y', ">u2"),
+              ('u', ">u2"),
+              ('v', ">u2")],
+             (self._height, self._width))
+        ])
+
+
+pixel_formats.register(YUV444I)
+pixel_formats.register(YUV444I10LE)
+pixel_formats.register(YUV444I10BE)
+pixel_formats.register(YUV444I16LE)
+pixel_formats.register(YUV444I16BE)
+pixel_formats.register(YUV444I9LE)
+pixel_formats.register(YUV444I9BE)
+pixel_formats.register(YUV444I12LE)
+pixel_formats.register(YUV444I12BE)
+pixel_formats.register(YUV444I14LE)
+pixel_formats.register(YUV444I14BE)


### PR DESCRIPTION
Interleaved YUV formats for 4:2:0, 4:2:2 and 4:4:4 chroma subsampling. The naming convention follows planar naming conventions replacing the "p" for planar by "i" for interleaved. Example: `'yuv420i10le'`: *Interleaved yuv 4:2:0 with 10 bits sample precision packed into 16 bit sample containers.*

* Though fully interleaved yuv 4:2:0 is uncommon, it may be useful for some applications. Fully interleaved yuv 4:2:0 is structured as follows: Even lines carry interleaved luma and chroma as [y0 u0 y1 v0 ...], while odd lines carry only luma as [y0 y1 ...]
* Interleaved yuv 4:2:2 and 4:4:4 are more common and are structued as [y0 u0 y1 v1 ...] (yuv 4:2:2) and [y0 u0 v0 y1 u1 v1 ...] (yuv 4:4:4)